### PR TITLE
remove sync for normal use, add queue

### DIFF
--- a/src/LoggerOptions.ts
+++ b/src/LoggerOptions.ts
@@ -6,6 +6,7 @@ type LoggerOptions = {
     color?: boolean;
     logDir?: string;
     logFile?: string;
+    dumpTime?: number;
 };
 
 export default LoggerOptions;


### PR DESCRIPTION
Replaces the creation of the log directory and writing of logs synchronously with a queue system that dumps every second, or to a user-defined interval

cleanup still runs sync, and if the dir creation steps have not completed when cleanup is ran, it will do those tasks synchronously